### PR TITLE
fix: update launchUrl for http, https, and IIS Express profiles to display swagger on dev launch

### DIFF
--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -5,6 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5067",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -14,7 +15,16 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7261;http://localhost:5067",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
This pull request updates the `launchSettings.json` configuration to improve the developer experience by setting the default launch URL to the Swagger UI and adding support for IIS Express. These changes make it easier to test and debug the API during development.

Launch configuration improvements:

* Set the default `launchUrl` to `"swagger"` for both the project and IIS Express profiles, so the Swagger UI opens automatically when running the application. [[1]](diffhunk://#diff-1e736f99b93d17b95e17cb5f5083d0bfc26d3cf27056d8e410398d18a055e195R8) [[2]](diffhunk://#diff-1e736f99b93d17b95e17cb5f5083d0bfc26d3cf27056d8e410398d18a055e195R18-R30)
* Added a new `IIS Express` profile with appropriate environment variables and launch settings, enhancing flexibility for local testing.